### PR TITLE
CFSSL Create truststore

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,50 @@ Will provide a server TLS cert on demand from a [cfssl server](https://github.co
 
 #### Kubernetes example sidekick or init container:
 
-```
+```YAML
+- name: certs
+ image: quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.5
+ securityContext:
+   runAsNonRoot: true
+ args:
+ - --certs=/certs
+ - --domain=servicename.${KUBE_NAMESPACE}.svc.cluster.local
+ - --expiry=8760h
+ env:
+ - name: KUBE_NAMESPACE
+   valueFrom:
+     fieldRef:
+       fieldPath: metadata.namespace
+ volumeMounts:
  - name: certs
-   image: quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.2
-   securityContext:
-     runAsNonRoot: true
-   args:
-   - --certs=/certs
-   - --domain=servicename.${KUBE_NAMESPACE}.svc.cluster.local
-   - --expiry=8760h
-   env:
-   - name: KUBE_NAMESPACE
-     valueFrom:
-       fieldRef:
-         fieldPath: metadata.namespace
-   volumeMounts:
-   - name: certs
-     mountPath: /certs
-   - name: bundle
-     mountPath: /etc/ssl/certs
-     readOnly: true
+   mountPath: /certs
+ - name: bundle
+   mountPath: /etc/ssl/certs
+   readOnly: true
 ```
+
+We always produce a Java version, which includes a create-keystore.sh script used to generate a Java key and trust store.
+
+```YAML
+- name: certs
+ image: quay.io/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.5
+ securityContext:
+   runAsNonRoot: true
+ args:
+ - --certs=/certs
+ - --domain=servicename.${KUBE_NAMESPACE}.svc.cluster.local
+ - --command=/usr/bin/create-keystore.sh /certs/tls.pem /certs/tls-key.pem /etc/ssl/certs/acp-root.crt
+ - --expiry=8760h
+ env:
+ - name: KUBE_NAMESPACE
+   valueFrom:
+     fieldRef:
+       fieldPath: metadata.namespace
+ volumeMounts:
+ - name: certs
+   mountPath: /certs
+ - name: bundle
+   mountPath: /etc/ssl/certs
+   readOnly: true
+```
+

--- a/scripts/create-keystore.sh
+++ b/scripts/create-keystore.sh
@@ -51,6 +51,7 @@ create_keystore() {
 CERTIFICATE_FILE=${1}
 PRIVATE_KEY_FILE=${2}
 CA_CERT_FILE=${1}
+[[ -n "${3}" ]] && CA_CERT_FILE="${3}"
 
 # step: at the very least we must have cert and private key
 [ -f "${CERTIFICATE_FILE}" ] || failed "cannot find the certificate file: ${CERTIFICATE_FILE}"


### PR DESCRIPTION
- fixing up the create-keystore.sh to support taking a ca file
- i've added this as an optional to ensure to don't break anything before people update 