### PR TITLE
Update cfssl-sidekick from v0.0.7 to v0.0.9

### DIFF
--- a/Dockerfile.jks
+++ b/Dockerfile.jks
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.7
+FROM quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.9
 MAINTAINER Rohith Jayawardene <gambol99@gmail.com>
 
 USER root


### PR DESCRIPTION
Update cfssl-sidekick from v0.0.7 to v0.0.9  to address the known vulnerabilities in v0.0.7.
As shown at https://quay.io/repository/ukhomeofficedigital/cfssl-sidekick?tab=tags
 