### PR TITLE
Update alpine and base image to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:20210212
 MAINTAINER Rohith Jayawardene <gambol99@gmail.com>
 
 RUN apk add curl openssl --update && \

--- a/Dockerfile.jks
+++ b/Dockerfile.jks
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.7
+FROM quay.io/ukhomeofficedigital/cfssl-sidekick:v0.0.9
 MAINTAINER Rohith Jayawardene <gambol99@gmail.com>
 
 USER root

--- a/doc.go
+++ b/doc.go
@@ -20,7 +20,7 @@ import "time"
 
 var (
 	// Version is the version on the sidekick
-	Version = "v0.0.7"
+	Version = "v0.0.9"
 	// GitSHA is the git sha we were built from
 	GitSHA = "no set"
 )


### PR DESCRIPTION
Update cfssl-sidekick from v0.0.7 to v0.0.9 to address the known vulnerabilities in v0.0.7.
As shown at https://quay.io/repository/ukhomeofficedigital/cfssl-sidekick?tab=tags